### PR TITLE
Refactor final project framework into version-based workflow

### DIFF
--- a/Final/Proposal/cooperation.md
+++ b/Final/Proposal/cooperation.md
@@ -1,6 +1,6 @@
 ## 协作
 
-看板：https://github.com/orgs/CS-546-B-FP/projects
+看板：https://github.com/users/Chris-Jin02/projects/3
 
 看板上的任务先认领再开始做，一个任务默认只由一个人主负责, 领完issue之后注意要在issue右侧Assignees把自己加进去
 


### PR DESCRIPTION
# Summary

- reorganized `Final/` into one shared data foundation plus three personal version tracks
- changed each version folder to the new structure: `EDA/`, `Experiments/`, `Results/`, `Notes/`
- moved the existing EDA work into `Version_A/EDA` and kept it as the A-version analysis
- updated project workflow documents to reflect that `Data` is the only shared technical base
- updated proposal and coordination docs to match the new version-based workflow

# Key Changes

- `Final/README.md` now describes the project as:
  - shared `Data`
  - personal `Version_A`, `Version_B`, `Version_C`
- `Final/Proposal/WORK_ORDER.md` now defines the new work order:
  - each member owns their own EDA
  - modeling, training, validation, and tuning stay together in `Experiments/`
  - outputs and metrics go to `Results/`
- `Final/Proposal/proposal.md` now reflects the new team split and execution plan
- `Final/Data/README.md` now explains that all versions should read from `Final/Data/Pure_Data`
- `Final/Proposal/1.md` now includes the new folder convention

# Version Structure

Each version now follows the same layout:

- `EDA/`
- `Experiments/`
- `Results/`
- `Notes/`

# Notes

- `Version_A` is reserved for my work
- `Version_B` and `Version_C` are reserved for teammates
- the old top-level `Final/EDA` structure has been removed from the active framework

# Verification

- checked the final directory structure under `Final/`
- checked markdown references so they match the new framework
- did not rerun notebooks or model training in this change
