### PR TITLE
docs: expand Version A framework

### DIFF
--- a/Final/Proposal/WORK_ORDER.md
+++ b/Final/Proposal/WORK_ORDER.md
@@ -42,12 +42,17 @@ Important:
 
 ### Version A
 Suggested direction:
-- popularity baseline
-- content-based recommendation
+- lightweight metadata-first recommendation
+- Bayesian popularity baseline
+- TF-IDF content-based recommendation
+- user-profile content recommendation
+- content plus popularity reranking
 
 Main purpose:
-- provide the strongest non-collaborative baseline
-- handle recipes that still have useful metadata even if interaction history is weak
+- provide the strongest non-collaborative model line
+- handle users and recipes with weak collaborative history
+- give the final comparison a strong, interpretable metadata-based alternative
+- stay computationally light enough for normal laptop experiments
 
 ### Version B
 Suggested direction:

--- a/Final/Version_A/Experiments/README.md
+++ b/Final/Version_A/Experiments/README.md
@@ -1,0 +1,45 @@
+# Version A Experiments
+
+This folder will contain the implementation and experiment logs for the lightweight metadata-first recommendation track.
+
+## Planned implementation files
+
+Recommended future files:
+
+- `version_a_recommenders.py`: model classes and scoring helpers
+- `run_version_a_experiments.py`: train/evaluate script for A0 through A4
+- `version_a_metrics.py`: Precision@K, Recall@K, NDCG@K, coverage, and runtime helpers
+- `experiment_log.md`: short record of what was run and what changed
+
+Keep the code small. The first complete script should evaluate A0, A2, A3, and A4 before adding optional extras.
+
+## Model order
+
+1. A0 Bayesian popularity
+2. A2 TF-IDF item-to-item content
+3. A3 user-profile content
+4. A4 content plus popularity reranker
+5. Optional A5 latent semantic content model
+
+## Output location
+
+Save generated outputs under:
+
+- `Final/Version_A/Results/`
+
+Expected outputs:
+
+- `version_a_metrics.csv`
+- `version_a_runtime.csv`
+- `version_a_example_recommendations.csv`
+- `version_a_model_notes.md`
+
+## Development rule
+
+Use the narrowest reliable check first:
+
+1. run on a few users
+2. run on a fixed sample of around `1,000` users
+3. run on the full filtered temporal test set
+
+Do not optimize before the basic ranking and metric pipeline is correct.

--- a/Final/Version_A/Experiments/experiment_log.md
+++ b/Final/Version_A/Experiments/experiment_log.md
@@ -1,0 +1,16 @@
+# Version A Experiment Log
+
+Use this file to record concise experiment notes.
+
+| Date | Model | Data split | Parameters | Key result | Decision |
+| --- | --- | --- | --- | --- | --- |
+| TBD | A0 Bayesian popularity | filtered temporal | TBD | TBD | TBD |
+| TBD | A2 TF-IDF content | filtered temporal | TBD | TBD | TBD |
+| TBD | A3 user-profile content | filtered temporal | TBD | TBD | TBD |
+| TBD | A4 content plus popularity rerank | filtered temporal | TBD | TBD | TBD |
+
+## Notes
+
+- Record only meaningful changes.
+- Include runtime when it affects model choice.
+- Keep failed runs if they explain why a simpler model was chosen.

--- a/Final/Version_A/Notes/EVALUATION_PROTOCOL.md
+++ b/Final/Version_A/Notes/EVALUATION_PROTOCOL.md
@@ -1,0 +1,74 @@
+# Version A Evaluation Protocol
+
+## Task
+
+Evaluate Top-N recommendation. For each user, recommend recipes from the training-time candidate catalog, exclude recipes already seen in training, and check whether the user's held-out recipe appears near the top.
+
+## Primary comparison split
+
+Use this split when comparing with Version B and Version C:
+
+- `Final/Data/Pure_Data/interactions_train_filtered.csv`
+- `Final/Data/Pure_Data/interactions_test_filtered.csv`
+
+This keeps Version A comparable to collaborative-filtering models that require train-side user and recipe support.
+
+## Secondary coverage split
+
+Use this split for Version A's own sparse-user and sparse-recipe story:
+
+- `Final/Data/Pure_Data/interactions_train.csv`
+- `Final/Data/Pure_Data/interactions_test.csv`
+
+This split shows where metadata methods have a practical advantage over pure collaborative filtering.
+
+## Metrics
+
+Report:
+
+- `Precision@10`
+- `Recall@10`
+- `NDCG@10`
+- `catalog_coverage@10`
+- evaluated user count
+- average runtime per evaluated user
+
+Optional:
+
+- `Precision@5`
+- `Recall@5`
+- `NDCG@5`
+- examples grouped by user history bucket
+
+## Leakage rules
+
+- Popularity scores must be computed from train interactions only.
+- User profiles must be built from train interactions only.
+- The held-out test recipe must not be used to build the user profile.
+- Recipe metadata can be used because item metadata is available before recommendation.
+- Full-history rating columns in `recipe_model_table.csv` may be displayed but should not be scoring features in evaluation.
+
+## Candidate rules
+
+Default candidate set:
+
+- recipes appearing in the training split for direct comparison
+
+Secondary candidate set:
+
+- all recipes in `recipe_model_table.csv` with valid metadata
+
+Always exclude:
+
+- recipes the user already rated in training
+- recipes filtered out by explicit practical constraints
+
+## Practical runtime rule
+
+Start with a fixed random sample of test users, for example `1,000` users. After the code is correct, run the full filtered test set.
+
+For the final report, clearly label whether metrics came from:
+
+- sampled filtered evaluation
+- full filtered evaluation
+- full clean temporal evaluation

--- a/Final/Version_A/Notes/MODEL_ROADMAP.md
+++ b/Final/Version_A/Notes/MODEL_ROADMAP.md
@@ -1,0 +1,158 @@
+# Version A Model Roadmap
+
+## Final direction
+
+Version A should become a strong **metadata-first recommender** rather than only a simple baseline. The project should still be lightweight: no deep learning, no full collaborative-filtering matrix factorization, and no long training jobs.
+
+The strongest practical route is:
+
+1. build a reliable popularity baseline
+2. build content similarity from recipe metadata
+3. personalize content results using each user's liked recipes
+4. rerank personalized content results with train-only popularity and simple constraints
+
+This creates a good high-score story: Version A is interpretable, fast, sparse-user friendly, and easy to demo.
+
+## Chosen models
+
+### A0 Bayesian popularity
+
+Purpose:
+
+- establish a stronger baseline than raw average rating
+- avoid overvaluing recipes with only a few high ratings
+- provide a stable fallback for users without enough history
+
+Suggested score:
+
+```text
+bayesian_score = (v / (v + m)) * R + (m / (v + m)) * C
+```
+
+Where:
+
+- `R` is the recipe's train average rating
+- `v` is the recipe's train rating count
+- `C` is the global train average rating
+- `m` is a minimum-support smoothing constant
+
+### A1 Constrained popularity
+
+Purpose:
+
+- support demo queries such as quick recipes, max cooking time, and ingredient exclusions
+- show practical usefulness beyond pure metrics
+
+This model uses the A0 score after filtering candidates.
+
+### A2 TF-IDF item-to-item content
+
+Purpose:
+
+- recommend recipes similar to a seed recipe
+- support cold-start items because it relies on metadata rather than interaction history
+- generate easy-to-explain examples based on shared tags and ingredients
+
+Recommended text fields:
+
+- recipe name
+- description
+- tags text
+- ingredients text
+- optional quick-recipe token
+
+Implementation note:
+
+- fit one `TfidfVectorizer`
+- do top-k sparse cosine search per seed recipe
+- do not materialize the full item-item similarity matrix
+
+### A3 User-profile content
+
+Purpose:
+
+- produce personalized recommendations without collaborative filtering
+- make Version A stronger than item-only similarity
+
+Method:
+
+- collect each user's liked recipes from the training split
+- use ratings `>= 4` as positive feedback
+- build a user vector as the weighted average of liked recipe TF-IDF vectors
+- score candidate recipes by cosine similarity to the user vector
+- exclude recipes already seen in training
+
+This should work especially well for users whose liked recipes share ingredients, tags, or cooking styles.
+
+### A4 Content plus popularity reranker
+
+Purpose:
+
+- produce the best Version A final model
+- combine personalization, quality control, and practical constraints
+
+Suggested score:
+
+```text
+final_score =
+  0.70 * normalized_content_score
+  + 0.25 * normalized_bayesian_popularity
+  + 0.05 * practical_filter_bonus
+```
+
+The exact weights should be tuned lightly. Avoid a large grid search. A small set such as `(0.8, 0.2)`, `(0.7, 0.25)`, and `(0.6, 0.35)` is enough.
+
+## Optional stretch
+
+### A5 Latent semantic content model
+
+Use `TruncatedSVD` on TF-IDF features only if the main pipeline is already working and runtime is acceptable.
+
+Why it may help:
+
+- reduces sparse text features into broader semantic dimensions
+- may improve recommendations when exact ingredient/tag overlap is too literal
+
+Why it is optional:
+
+- it adds training time
+- it may not improve Top-N metrics enough to justify complexity
+
+## Evaluation plan
+
+Primary metrics:
+
+- Precision@10
+- Recall@10
+- NDCG@10
+- catalog coverage
+- average recommendation runtime per user
+
+Primary split:
+
+- train: `interactions_train_filtered.csv`
+- test: `interactions_test_filtered.csv`
+
+Secondary sparse-coverage analysis:
+
+- train: `interactions_train.csv`
+- test: `interactions_test.csv`
+
+The secondary analysis is useful because content models can recommend across a wider recipe universe than collaborative-filtering models.
+
+## Expected final table
+
+| Model | Precision@10 | Recall@10 | NDCG@10 | Coverage | Runtime | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| A0 Bayesian popularity | TBD | TBD | TBD | TBD | TBD | Non-personalized baseline |
+| A2 TF-IDF item content | TBD | TBD | TBD | TBD | TBD | Similar-recipe content model |
+| A3 User-profile content | TBD | TBD | TBD | TBD | TBD | Personalized metadata model |
+| A4 Content plus popularity rerank | TBD | TBD | TBD | TBD | TBD | Best Version A candidate |
+
+## Risks and controls
+
+- If full evaluation is slow, evaluate on a reproducible sample first.
+- If TF-IDF is too memory-heavy, lower `max_features`.
+- If content scores recommend obscure low-quality recipes, increase the popularity weight in A4.
+- If popularity dominates too much, lower its weight and report improved personalization.
+- If metrics are modest, emphasize coverage, interpretability, and sparse-history usefulness.

--- a/Final/Version_A/Notes/WORKFLOW.md
+++ b/Final/Version_A/Notes/WORKFLOW.md
@@ -1,20 +1,50 @@
 # Version A Workflow
 
-This folder is for your recommendation version.
+Version A is the lightweight metadata-first recommendation track.
 
-Recommended order:
-1. add your own EDA note or notebook in `EDA/`
-2. build, fit, validate, and tune the main model in `Experiments/`
-3. save metric tables, recommendation examples, and final outputs in `Results/`
-4. summarize strengths, weaknesses, and example recommendations in `Notes/`
+## Recommended order
 
-Recommended model direction:
-- popularity baseline
-- content-based recommendation
+1. Keep the existing EDA as the evidence base.
+2. Implement a train-only Bayesian popularity baseline.
+3. Implement TF-IDF item-to-item recipe similarity.
+4. Implement user-profile content recommendation from liked recipes.
+5. Add a lightweight content-plus-popularity reranker.
+6. Evaluate the models under the shared temporal split.
+7. Save metric tables, recommendation examples, and short conclusions in `Results/`.
 
-Shared inputs:
-- `Final/Data/Pure_Data`
+## Model priority
 
-Important:
-- do not redo raw data cleaning here
-- keep this version comparable to `Version_B` and `Version_C`
+Build in this order:
+
+| Priority | Model | Reason |
+| --- | --- | --- |
+| 1 | A0 Bayesian popularity | Fast baseline and sanity check |
+| 2 | A2 TF-IDF item similarity | Core content model and demo-friendly examples |
+| 3 | A3 user-profile content | Personalized recommendation without heavy training |
+| 4 | A4 content plus popularity rerank | Best candidate for Version A final result |
+| 5 | Optional SVD content model | Only if the main models run comfortably |
+
+## Evaluation rule
+
+Primary comparison should use the same temporal setup as the other versions:
+
+- train from `interactions_train_filtered.csv` when comparing directly with CF models
+- test on `interactions_test_filtered.csv`
+- report Precision@10, Recall@10, NDCG@10, catalog coverage, and runtime
+
+Secondary analysis may use `interactions_train.csv` and `interactions_test.csv` to show that content-based methods cover more sparse users and recipes than collaborative filtering.
+
+## Runtime guardrails
+
+- Do not build a full recipe-by-recipe similarity matrix.
+- Use sparse TF-IDF operations and retrieve only top candidates.
+- Start evaluation on a sampled user set, then scale to the filtered test users.
+- Keep TF-IDF feature limits moderate, for example `20,000` to `30,000` features.
+- Treat `TruncatedSVD` as optional, not required.
+
+## Important
+
+- Do not redo raw data cleaning here.
+- Use `Final/Data/Pure_Data` as the canonical input.
+- Use only train interactions to compute popularity scores during evaluation.
+- Keep this version distinct from `Version_B` collaborative filtering and `Version_C` final hybrid work.

--- a/Final/Version_A/README.md
+++ b/Final/Version_A/README.md
@@ -1,20 +1,73 @@
 # Version A
 
-Purpose:
-- this is your version folder
-- use it for your full recommendation line from model-specific EDA to evaluation notes
+## Target outcome
 
-Suggested use:
-- use this folder for the simplest strong baseline or the first chosen model family
-- a good default is popularity plus content-based recommendation
+Version A is now the **lightweight metadata-first recommendation track**.
 
-Workflow inside this folder:
-1. `EDA/`: your own EDA for this version using shared processed data
-2. `Experiments/`: model building, fitting, validation, and tuning
-3. `Results/`: outputs scored on the shared temporal split
-4. `Notes/`: decisions, limitations, and summary write-ups
+The goal is to build several strong, fast recommenders that can run on a normal laptop and still give the final project a convincing comparison story. This version should be stronger than a plain popularity baseline, but it should not become a heavy collaborative-filtering or deep-learning track.
 
-Rules:
-- do not duplicate raw data or full preprocessing here
-- use `Final/Data/Pure_Data` as the canonical shared input
-- keep this version clearly distinguishable from `Version_B` and `Version_C`
+## Updated task
+
+Version A owns:
+
+- popularity baselines
+- TF-IDF content-based recommendation
+- user-profile content recommendation
+- a lightweight content-plus-popularity reranker
+- practical filters such as maximum time, quick recipes, and ingredient or tag constraints
+
+Version A does not own:
+
+- full collaborative filtering
+- matrix factorization on the user-item matrix
+- the final cross-version hybrid with collaborative signals
+- LLM explanation features
+
+Those should remain separate from this version so the three project tracks stay distinguishable.
+
+## Model lineup
+
+| ID | Model | Why it belongs in Version A | Expected cost |
+| --- | --- | --- | --- |
+| A0 | Bayesian popularity baseline | Stronger and fairer than raw average rating because it controls for low rating counts | Very low |
+| A1 | Time/tag constrained popularity | Useful demo model for quick meals and dietary constraints | Very low |
+| A2 | TF-IDF item-to-item content model | Uses recipe name, description, tags, and ingredients; strong for similar-recipe search | Low |
+| A3 | User-profile content model | Builds a user preference vector from liked recipes; gives personalized results without collaborative training | Low to medium |
+| A4 | Content plus popularity reranker | Combines A3 relevance with train-only popularity and practical filters; likely Version A's best final model | Medium |
+
+Optional stretch only if runtime is comfortable:
+
+- latent semantic content model using `TruncatedSVD` on TF-IDF features
+
+## Folder roles
+
+- `EDA/`: completed Version A exploratory analysis and report-ready figures
+- `Experiments/`: implementation plan, experiment log, and future model/evaluation scripts
+- `Results/`: metric tables, recommendation examples, and report summaries
+- `Notes/`: task definition, model roadmap, evaluation protocol, and limitations
+
+## Shared inputs
+
+All experiments should read from `Final/Data/Pure_Data`.
+
+Recommended files:
+
+- `recipe_model_table.csv`
+- `interactions_train.csv`
+- `interactions_test.csv`
+- `interactions_train_filtered.csv`
+- `interactions_test_filtered.csv`
+- `preprocessing_summary.json`
+- `temporal_split_summary.json`
+
+Use train interactions for all popularity statistics during evaluation. Do not use full-history rating columns as scoring features when measuring test performance.
+
+## Success criteria
+
+Version A should produce:
+
+- at least three evaluated models: A0, A2, and A4
+- Top-N metrics such as Precision@10, Recall@10, NDCG@10, and coverage
+- a small table comparing runtime and quality
+- several readable recommendation examples for the final report or presentation
+- a clear explanation of why metadata helps sparse users and low-history recipes

--- a/Final/Version_A/Results/README.md
+++ b/Final/Version_A/Results/README.md
@@ -1,0 +1,58 @@
+# Version A Results
+
+This folder should hold generated metrics, recommendation examples, and report-ready summaries for Version A.
+
+## Expected files
+
+- `version_a_metrics.csv`
+- `version_a_runtime.csv`
+- `version_a_example_recommendations.csv`
+- `version_a_model_notes.md`
+
+## Metric table schema
+
+Recommended columns for `version_a_metrics.csv`:
+
+- `model_id`
+- `model_name`
+- `split`
+- `k`
+- `evaluated_users`
+- `precision_at_k`
+- `recall_at_k`
+- `ndcg_at_k`
+- `catalog_coverage_at_k`
+
+## Runtime table schema
+
+Recommended columns for `version_a_runtime.csv`:
+
+- `model_id`
+- `fit_seconds`
+- `recommend_seconds_total`
+- `recommend_seconds_per_user`
+- `evaluated_users`
+- `candidate_count`
+
+## Example recommendations
+
+Recommended columns for `version_a_example_recommendations.csv`:
+
+- `model_id`
+- `user_id`
+- `rank`
+- `recipe_id`
+- `recipe_name`
+- `score`
+- `minutes`
+- `matched_tags_or_ingredients`
+- `reason`
+
+## Reporting focus
+
+The final Version A write-up should emphasize:
+
+- A4 as the strongest metadata-first model if metrics support it
+- A0 as a fair baseline
+- A2 and A3 as interpretable content models
+- coverage and sparse-history usefulness as Version A's major advantage


### PR DESCRIPTION
## Summary

Expanded Version A from a simple popularity/content baseline into a lightweight metadata-first recommendation track.

## Changes

- Updated `Final/Version_A/README.md` with the new Version A task, model lineup, boundaries, shared inputs, and success criteria.
- Updated `Final/Version_A/Notes/WORKFLOW.md` with the recommended build order, evaluation setup, and runtime guardrails.
- Added `MODEL_ROADMAP.md` for the planned Version A models:
  - A0 Bayesian popularity
  - A1 constrained popularity
  - A2 TF-IDF item-to-item content
  - A3 user-profile content recommendation
  - A4 content plus popularity reranker
  - optional A5 TruncatedSVD content model
- Added `EVALUATION_PROTOCOL.md` to define Top-N metrics, temporal split usage, leakage rules, and candidate rules.
- Added experiment and result folder README files plus an experiment log template.
- Updated `Final/Proposal/WORK_ORDER.md` so the team task description matches the expanded Version A direction.

## Why

Version A now has a clearer high-score path: fast, interpretable, metadata-driven models that avoid long training while still producing a strong comparison against collaborative filtering and hybrid tracks.

## Verification

- Documentation-only change.
- Checked current diff scope with `git diff --stat`.
- No model training or data regeneration was run.
